### PR TITLE
chore: assume array in for-of transform

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   presets: [['@babel/preset-env']],
+  plugins: [['@babel/plugin-transform-for-of', { assumeArray: true }]],
 };

--- a/index.js
+++ b/index.js
@@ -12,32 +12,14 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 function levenArray(str, array) {
   var minLeven = Number.POSITIVE_INFINITY;
   var result = undefined;
-  var _iteratorNormalCompletion = true;
-  var _didIteratorError = false;
-  var _iteratorError = undefined;
 
-  try {
-    for (var _iterator = array[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
-      var item = _step.value;
-      var distance = (0, _leven.default)(str, item);
+  for (var _i2 = 0; _i2 < array.length; _i2++) {
+    var item = array[_i2];
+    var distance = (0, _leven.default)(str, item);
 
-      if (distance < minLeven) {
-        minLeven = distance;
-        result = item;
-      }
-    }
-  } catch (err) {
-    _didIteratorError = true;
-    _iteratorError = err;
-  } finally {
-    try {
-      if (!_iteratorNormalCompletion && _iterator.return != null) {
-        _iterator.return();
-      }
-    } finally {
-      if (_didIteratorError) {
-        throw _iteratorError;
-      }
+    if (distance < minLeven) {
+      minLeven = distance;
+      result = item;
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "devDependencies": {
     "@babel/cli": "^7.7.5",
     "@babel/core": "^7.7.5",
+    "@babel/plugin-transform-for-of": "^7.7.4",
     "@babel/preset-env": "^7.7.6",
     "babel-jest": "^24.9.0",
     "bench": "^0.3.6",


### PR DESCRIPTION
In this PR I reduces the unpacked npm package size from 5.1 kB to 4.6 kB.

Technically it is a breaking change since one can not supply a general iterable object to the second argument `levernary(str, array)`, however, I think it is okay to restrict `array` to be plain array.

Related: Nicolò is proposing to replace `js-levenstein` by `levenary` in https://github.com/babel/babel/pull/10924.