### PR TITLE
fix: downgrade engine requirement to support node 6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        node-version: [8, 10, 12]
+        node-version: [6, 8, 10, 12]
         os: [ubuntu-latest, windows-latest, macOS-latest]
     steps:
     - run: git config --global core.autocrlf false

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "index.flow.js"
   ],
   "engines": {
-    "node": ">= 8"
+    "node": ">= 6"
   },
   "devDependencies": {
     "@babel/cli": "^7.7.5",


### PR DESCRIPTION
Otherwise using this module in Babel is a breaking change. See https://github.com/babel/babel/pull/10924#issuecomment-578820561